### PR TITLE
Typo during live coding workshop

### DIFF
--- a/src/ai/llm/WebLLM.ts
+++ b/src/ai/llm/WebLLM.ts
@@ -11,8 +11,8 @@ import {
   
     public createConversation = (systemPrompt: string) => {
       const messages: Array<ChatCompletionMessageParam> = [
-        { role: "system", content:  },
-      ];systemPrompt
+        { role: "system", content: systemPrompt },
+      ];
   
       console.log("-- SYSTEM PROMPT --");
       console.log(systemPrompt);


### PR DESCRIPTION
This was an errant drag and drop mistake during the live coding session! I noticed it in realtime, but wasn't sure if it was committed or not, but it was.

This should get things back working again.

